### PR TITLE
Cleanup old image builder instances

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ voluptuous
 kazoo
 Paste
 WebOb>=1.2.3
+iso8601


### PR DESCRIPTION
Nodepool should do this as part of the image build process
once the image is successfully created, but appears to be
having trouble with that, so this is a safety net to periodically
come behind and clean up after the nightly image build process.

closes #3
